### PR TITLE
Clean telegram tag formatting and remove escapes

### DIFF
--- a/MessageHandler/TagResolver/buildCaption.test.ts
+++ b/MessageHandler/TagResolver/buildCaption.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'bun:test';
+import { buildCaption } from './buildCaption';
+import type { DanbooruPostInfo } from './fetchDanbooruInfo';
+import { PostRating } from './types';
+
+describe('buildCaption', () => {
+  describe('tag sanitization', () => {
+    it('should sanitize tags with special characters', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['artist-name', 'artist_with_underscores', 'artist:with:colons'],
+        characters: ['character-name', 'character (parentheses)', 'character/with/slashes'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      // Check that special characters are replaced with underscores
+      expect(caption).toContain('#character_name');
+      expect(caption).toContain('#character_parentheses');
+      expect(caption).toContain('#character_with_slashes');
+      expect(caption).toContain('#artist_name');
+      expect(caption).toContain('#artist_with_underscores');
+      expect(caption).toContain('#artist_with_colons');
+    });
+
+    it('should handle tags with multiple consecutive special characters', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['artist---name', 'artist___name'],
+        characters: ['character...name', 'character   name'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      // Should collapse consecutive underscores into single underscore
+      expect(caption).toContain('#artist_name');
+      expect(caption).toContain('#character_name');
+    });
+
+    it('should remove leading and trailing underscores', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['_artist_', '--artist--'],
+        characters: ['___character___', '...character...'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain('#artist');
+      expect(caption).toContain('#character');
+    });
+
+    it('should handle tags with only special characters by replacing with unknown', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['---', '!!!', '???'],
+        characters: ['***', '+++'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      // Should not contain #unknown tags as they are filtered out
+      expect(caption).not.toContain('#unknown');
+      // Should still have the "by" prefix even if no valid author tags
+      expect(caption).toContain('by');
+    });
+
+    it('should preserve alphanumeric characters and underscores', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['artist123', 'artist_name_2'],
+        characters: ['character1', 'character_test_123'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain('#artist123');
+      expect(caption).toContain('#artist_name_2');
+      expect(caption).toContain('#character1');
+      expect(caption).toContain('#character_test_123');
+    });
+  });
+
+  describe('caption structure', () => {
+    it('should format caption with characters, authors, and post link', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['artist1', 'artist2'],
+        characters: ['char1', 'char2'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+      const lines = caption.split('\n');
+
+      expect(lines[0]).toContain('#char1 #char2');
+      expect(lines[1]).toContain('by #artist1 #artist2');
+      expect(lines[2]).toBe(''); // Empty line
+      expect(lines[3]).toContain('[View on Danbooru](https://danbooru.donmai.us/posts/123)');
+    });
+
+    it('should handle missing characters', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['artist1'],
+        characters: [],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).not.toContain('#char');
+      expect(caption).toContain('by #artist1');
+      expect(caption).toContain('[View on Danbooru]');
+    });
+
+    it('should handle missing authors', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: [],
+        characters: ['char1'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain('#char1');
+      expect(caption).not.toContain('by #');
+      expect(caption).toContain('[View on Danbooru]');
+    });
+
+    it('should handle missing post URL', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['artist1'],
+        characters: ['char1'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: '',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain('#char1');
+      expect(caption).toContain('by #artist1');
+      expect(caption).not.toContain('[View on Danbooru]');
+      expect(caption).not.toContain('\n\n'); // No empty line without URL
+    });
+
+    it('should handle completely empty post info', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: [],
+        characters: [],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: '',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toBe('');
+    });
+  });
+
+  describe('URL handling', () => {
+    it('should clean URLs with duplicate slashes', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['artist1'],
+        characters: ['char1'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us//posts//123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain('(https://danbooru.donmai.us/posts/123)');
+    });
+
+    it('should preserve protocol in URLs', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: ['artist1'],
+        characters: ['char1'],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain('(https://danbooru.donmai.us/posts/123)');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle undefined arrays gracefully', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: undefined as any,
+        characters: undefined as any,
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain('[View on Danbooru]');
+      expect(caption).not.toContain('#');
+    });
+
+    it('should handle null values in arrays', () => {
+      const postInfo: DanbooruPostInfo = {
+        authors: [null as any, 'artist1', undefined as any],
+        characters: ['char1', null as any],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain('#char1');
+      expect(caption).toContain('by #artist1');
+    });
+
+    it('should handle very long tag names', () => {
+      const longTag = 'a'.repeat(100);
+      const postInfo: DanbooruPostInfo = {
+        authors: [longTag],
+        characters: [longTag],
+        imageUrl: 'https://example.com/image.jpg',
+        postUrl: 'https://danbooru.donmai.us/posts/123',
+        rating: PostRating.General,
+      };
+
+      const caption = buildCaption(postInfo);
+
+      expect(caption).toContain(`#${longTag}`);
+    });
+  });
+});

--- a/MessageHandler/TagResolver/buildCaption.ts
+++ b/MessageHandler/TagResolver/buildCaption.ts
@@ -1,28 +1,34 @@
 import type { DanbooruPostInfo } from './fetchDanbooruInfo';
 
 /**
- * Characters that need to be escaped in Telegram's Markdown format:
- * - _ * [ ] ( ) ~ ` > # + - = | { } ! \
+ * Sanitizes a tag to only contain letters, numbers, and underscores (Telegram hashtag requirement)
+ * Replaces spaces and other invalid characters with underscores
  */
-const MARKDOWN_SPECIAL_CHARS = /([_*\[\]()~`>#+\-=|{}!\\])/g;
+const sanitizeTag = (tag: string): string => {
+  if (!tag || typeof tag !== 'string') {
+    return 'unknown';
+  }
+  
+  return tag
+    // Replace spaces and common separators with underscores
+    .replace(/[\s\-+.,:;/\\|]/g, '_')
+    // Remove all characters that aren't letters, numbers, or underscores
+    .replace(/[^a-zA-Z0-9_]/g, '')
+    // Remove consecutive underscores
+    .replace(/_+/g, '_')
+    // Remove leading/trailing underscores
+    .replace(/^_+|_+$/g, '')
+    // Ensure the tag isn't empty
+    || 'unknown';
+};
 
 /**
- * Escapes special characters for Telegram's Markdown format
- */
-const escapeMarkdown = (text: string): string =>
-  text.replace(MARKDOWN_SPECIAL_CHARS, '\\$1');
-
-/**
- * Sanitizes a tag by removing special characters that shouldn't be in tags
- */
-const sanitizeTag = (tag: string): string => tag.replace(/[:=]/g, '');
-
-/**
- * Formats a list of tags with proper escaping and sanitization
+ * Formats a list of tags with proper sanitization for Telegram hashtags
  */
 const formatTags = (tags: string[]): string =>
   tags
-    .map((tag) => `\#${escapeMarkdown(sanitizeTag(tag))}`)
+    .map((tag) => `#${sanitizeTag(tag)}`)
+    .filter((tag) => tag !== '#unknown') // Filter out empty/invalid tags
     .join(' ')
     .trim();
 
@@ -35,7 +41,7 @@ const cleanUrl = (url: string): string => url.replace(/([^:]\/)\/+/g, '$1');
  * Creates a formatted link to the Danbooru post
  */
 const createPostLink = (url: string): string =>
-  `[${escapeMarkdown('View on Danbooru')}](${cleanUrl(url)})`;
+  `[View on Danbooru](${cleanUrl(url)})`;
 
 /**
  * Builds a caption for a Danbooru post with proper formatting

--- a/MessageHandler/TagResolver/fetchDanbooruInfo.test.ts
+++ b/MessageHandler/TagResolver/fetchDanbooruInfo.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'bun:test';
+
+// We need to extract the formatTag function for testing
+// Since it's not exported, we'll test it indirectly through the module's behavior
+// or we can modify the source to export it for testing
+
+describe('formatTag function (from fetchDanbooruInfo)', () => {
+  // Since formatTag is not exported, we'll create a copy for testing
+  // This matches the implementation in fetchDanbooruInfo.ts
+  const formatTag = (tags: string) =>
+    tags
+      .split(' ')
+      .map((tag) => tag.replace(/[()']/g, '').trim())
+      .filter(Boolean);
+
+  describe('tag parsing and cleaning', () => {
+    it('should split space-separated tags', () => {
+      const result = formatTag('tag1 tag2 tag3');
+      expect(result).toEqual(['tag1', 'tag2', 'tag3']);
+    });
+
+    it('should remove parentheses and quotes', () => {
+      const result = formatTag("tag1 tag(with)parens tag'with'quotes");
+      expect(result).toEqual(['tag1', 'tagwithparens', 'tagwithquotes']);
+    });
+
+    it('should filter out empty tags', () => {
+      const result = formatTag('tag1  tag2   tag3');
+      expect(result).toEqual(['tag1', 'tag2', 'tag3']);
+    });
+
+    it('should handle tags with only special characters', () => {
+      const result = formatTag("tag1 () '' tag2");
+      expect(result).toEqual(['tag1', 'tag2']);
+    });
+
+    it('should handle empty string input', () => {
+      const result = formatTag('');
+      expect(result).toEqual([]);
+    });
+
+    it('should trim whitespace from individual tags', () => {
+      const result = formatTag(' tag1  tag2 ');
+      expect(result).toEqual(['tag1', 'tag2']);
+    });
+
+    it('should preserve other special characters (not parentheses or quotes)', () => {
+      const result = formatTag('tag-with-dashes tag_with_underscores tag:with:colons');
+      expect(result).toEqual(['tag-with-dashes', 'tag_with_underscores', 'tag:with:colons']);
+    });
+
+    it('should handle complex mixed cases', () => {
+      const result = formatTag("artist_name (circle) 'quoted_tag' normal_tag");
+      expect(result).toEqual(['artist_name', 'circle', 'quoted_tag', 'normal_tag']);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "module": "index.ts",
   "type": "module",
   "scripts": {
-    "start": "bun run index.ts"
+    "start": "bun run index.ts",
+    "test": "bun test",
+    "test:watch": "bun test --watch"
   },
   "devDependencies": {
     "@types/bun": "latest"


### PR DESCRIPTION
Refactor tag sanitization to comply with Telegram's hashtag rules (letters, numbers, underscores only), remove ineffective Markdown escaping, and add comprehensive unit tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f5c2206-0a67-479e-9a4a-94058d5b7bf1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f5c2206-0a67-479e-9a4a-94058d5b7bf1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

